### PR TITLE
feat: add option `reactCompat` that capitalizes vendor prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ parse(`
   -moz-transition: all 4s ease;
   -ms-transition: all 4s ease;
   -o-transition: all 4s ease;
+  -khtml-transition: all 4s ease;
 `);
 ```
 
@@ -119,7 +120,8 @@ Output:
   "webkitTransition": "all 4s ease",
   "mozTransition": "all 4s ease",
   "msTransition": "all 4s ease",
-  "oTransition": "all 4s ease"
+  "oTransition": "all 4s ease",
+  "khtmlTransition": "all 4s ease"
 }
 ```
 
@@ -186,6 +188,43 @@ The following values will throw an error:
 ```js
 parse('top'); // Uncaught Error: property missing ':'
 parse('/*'); // Uncaught Error: End of comment missing
+```
+
+### Options
+
+#### reactCompat
+
+When option `reactCompat` is true, the [vendor prefix](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix) will be capitalized:
+
+```js
+parse(
+  `
+    -webkit-transition: all 4s ease;
+    -moz-transition: all 4s ease;
+    -ms-transition: all 4s ease;
+    -o-transition: all 4s ease;
+    -khtml-transition: all 4s ease;
+  `,
+  { reactCompat: true }
+);
+```
+
+Output:
+
+```json
+{
+  "WebkitTransition": "all 4s ease",
+  "MozTransition": "all 4s ease",
+  "MsTransition": "all 4s ease",
+  "OTransition": "all 4s ease",
+  "KhtmlTransition": "all 4s ease"
+}
+```
+
+This helps resolve the React warning:
+
+```
+Warning: Unsupported vendor-prefixed style property %s. Did you mean %s?%s", "oTransition", "OTransition"
 ```
 
 ## Testing

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`option \`reactCompat\` capitalizes vendor prefixes 1`] = `
+Object {
+  "KhtmlUserSelect": "none",
+  "MozUserSelect": "-moz-none",
+  "MsUserSelect": "none",
+  "OUserSelect": "none",
+  "WebkitUserSelect": "none",
+  "userSelect": "none",
+}
+`;
+
 exports[`parses background style to object 1`] = `
 Object {
   "background": "url(data:image/png; base64,ivborw0kggoaaaansaaaabgdbtueaalgpc/xhbqaaaafzmuexurczmzpf399fx1+bm5mzy9avzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8u8czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif)",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -58,3 +58,19 @@ it('parses style with no spaces to object', () => {
     'border-bottom-left-radius:1em;border-right-style:solid;Z-Index:-1;-moz-border-radius-bottomleft:20px';
   expect(styleToJS(style)).toMatchSnapshot();
 });
+
+describe('option `reactCompat`', () => {
+  const options = { reactCompat: true };
+
+  it('capitalizes vendor prefixes', () => {
+    const style = `
+      -khtml-user-select: none;
+      -moz-user-select: -moz-none;
+      -ms-user-select: none;
+      -o-user-select: none;
+      -webkit-user-select: none;
+      user-select: none;
+    `;
+    expect(styleToJS(style, options)).toMatchSnapshot();
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -21,46 +21,40 @@ it.each(['top:', ':12px', ':', ';'])('parses "%s" to empty object', (text) => {
 });
 
 it('parses common styles to object', () => {
-  expect(
-    styleToJS(`
-      color: #f00;
-      font-size: 42px;
-      z-index: -1;
-    `)
-  ).toMatchSnapshot();
+  const style = `
+    color: #f00;
+    font-size: 42px;
+    z-index: -1;
+  `;
+  expect(styleToJS(style)).toMatchSnapshot();
 });
 
 it('parses style with vendor prefix to object', () => {
-  expect(
-    styleToJS(`
-      display: -ms-grid;
-      display: grid;
-      -webkit-transition: all .5s;
-      -o-transition: all .5s;
-      transition: all .5s;
-      -webkit-user-select: none;
-        -moz-user-select: none;
-          -ms-user-select: none;
-              user-select: none;
-      background: -webkit-gradient(linear, left top, left bottom, from(white), to(black));
-      background: -o-linear-gradient(top, white, black);
-      background: linear-gradient(to bottom, white, black);
-    `)
-  ).toMatchSnapshot();
+  const style = `
+    display: -ms-grid;
+    display: grid;
+    -webkit-transition: all .5s;
+    -o-transition: all .5s;
+    transition: all .5s;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    background: -webkit-gradient(linear, left top, left bottom, from(white), to(black));
+    background: -o-linear-gradient(top, white, black);
+    background: linear-gradient(to bottom, white, black);
+  `;
+  expect(styleToJS(style)).toMatchSnapshot();
 });
 
 it('parses background style to object', () => {
-  expect(
-    styleToJS(`
-      background: url(data:image/png; base64,ivborw0kggoaaaansaaaabgdbtueaalgpc/xhbqaaaafzmuexurczmzpf399fx1+bm5mzy9avzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8u8czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif)
-    `)
-  ).toMatchSnapshot();
+  const style =
+    'background: url(data:image/png; base64,ivborw0kggoaaaansaaaabgdbtueaalgpc/xhbqaaaafzmuexurczmzpf399fx1+bm5mzy9avzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8u8czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif)';
+  expect(styleToJS(style)).toMatchSnapshot();
 });
 
 it('parses style with no spaces to object', () => {
-  expect(
-    styleToJS(
-      'border-bottom-left-radius:1em;border-right-style:solid;Z-Index:-1;-moz-border-radius-bottomleft:20px'
-    )
-  ).toMatchSnapshot();
+  const style =
+    'border-bottom-left-radius:1em;border-right-style:solid;Z-Index:-1;-moz-border-radius-bottomleft:20px';
+  expect(styleToJS(style)).toMatchSnapshot();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,27 @@
 import StyleToObject from 'style-to-object';
-import { camelCase } from './utilities';
+import { camelCase, CamelCaseOptions } from './utilities';
 
 type StyleObject = Record<string, string>;
+
+interface StyleToJSOptions extends CamelCaseOptions {}
 
 /**
  * Parses CSS inline style to JavaScript object (camelCased).
  */
-export default function StyleToJS(style: string): StyleObject {
-  if (!style || typeof style !== 'string') {
-    return {};
-  }
-
+export default function StyleToJS(
+  style: string,
+  options?: StyleToJSOptions
+): StyleObject {
   const output: StyleObject = {};
+
+  if (!style || typeof style !== 'string') {
+    return output;
+  }
 
   StyleToObject(style, (property, value) => {
     // skip CSS comment
     if (property && value) {
-      output[camelCase(property)] = value;
+      output[camelCase(property, options)] = value;
     }
   });
 

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -41,4 +41,19 @@ describe('camelCase', () => {
   ])('transforms "%s" to "%s"', (property, expected) => {
     expect(camelCase(property)).toBe(expected);
   });
+
+  describe('option `reactCompat`', () => {
+    const options = { reactCompat: true };
+
+    it.each([
+      ['-khtml-transition', 'KhtmlTransition'],
+      ['-o-transition', 'OTransition'],
+      ['-moz-user-select', 'MozUserSelect'],
+      ['-ms-user-select', 'MsUserSelect'],
+      ['-webkit-transition', 'WebkitTransition'],
+      ['-webkit-user-select', 'WebkitUserSelect'],
+    ])('capitalizes vendor prefix "%s" to "%s"', (property, expected) => {
+      expect(camelCase(property, options)).toBe(expected);
+    });
+  });
 });

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -24,11 +24,12 @@ describe('camelCase', () => {
 
   // vendor prefix
   it.each([
-    ['-webkit-transition', 'webkitTransition'],
-    ['-o-transition', 'oTransition'],
-    ['-webkit-user-select', 'webkitUserSelect'],
+    ['-khtml-transition', 'khtmlTransition'],
     ['-moz-user-select', 'mozUserSelect'],
     ['-ms-user-select', 'msUserSelect'],
+    ['-o-transition', 'oTransition'],
+    ['-webkit-transition', 'webkitTransition'],
+    ['-webkit-user-select', 'webkitUserSelect'],
   ])('transforms vendor prefix "%s" to "%s"', (property, expected) => {
     expect(camelCase(property)).toBe(expected);
   });

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,7 +1,7 @@
 const CUSTOM_PROPERTY_REGEX = /^--[a-zA-Z0-9-]+$/;
 const HYPHEN_REGEX = /-([a-z])/g;
 const NO_HYPHEN_REGEX = /^[^-]+$/;
-const VENDOR_PREFIX_REGEX = /^-(webkit|moz|ms|o)-/;
+const VENDOR_PREFIX_REGEX = /^-(webkit|moz|ms|o|khtml)-/;
 
 /**
  * Checks whether to skip camelCase.

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -4,19 +4,33 @@ const NO_HYPHEN_REGEX = /^[^-]+$/;
 const VENDOR_PREFIX_REGEX = /^-(webkit|moz|ms|o)-/;
 
 /**
+ * Checks whether to skip camelCase.
+ */
+const skipCamelCase = (property: string) =>
+  !property ||
+  NO_HYPHEN_REGEX.test(property) ||
+  CUSTOM_PROPERTY_REGEX.test(property);
+
+/**
+ * Replacer that capitalizes first character.
+ */
+const capitalize = (match: string, character: string) =>
+  character.toUpperCase();
+
+/**
+ * Replacer that removes beginning hyphen of vendor prefix property.
+ */
+const trimHyphen = (match: string, prefix: string) => `${prefix}-`;
+
+/**
  * CamelCases a CSS property.
  */
 export const camelCase = (property: string) => {
-  if (
-    !property ||
-    NO_HYPHEN_REGEX.test(property) ||
-    CUSTOM_PROPERTY_REGEX.test(property)
-  ) {
+  if (skipCamelCase(property)) {
     return property;
   }
 
-  return property
-    .toLowerCase()
-    .replace(VENDOR_PREFIX_REGEX, (_, prefix) => `${prefix}-`)
-    .replace(HYPHEN_REGEX, (_, character) => character.toUpperCase());
+  property = property.toLowerCase();
+  property = property.replace(VENDOR_PREFIX_REGEX, trimHyphen);
+  return property.replace(HYPHEN_REGEX, capitalize);
 };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -23,14 +23,26 @@ const capitalize = (match: string, character: string) =>
 const trimHyphen = (match: string, prefix: string) => `${prefix}-`;
 
 /**
+ * CamelCase options.
+ */
+export interface CamelCaseOptions {
+  reactCompat?: boolean;
+}
+
+/**
  * CamelCases a CSS property.
  */
-export const camelCase = (property: string) => {
+export const camelCase = (property: string, options: CamelCaseOptions = {}) => {
   if (skipCamelCase(property)) {
     return property;
   }
 
   property = property.toLowerCase();
-  property = property.replace(VENDOR_PREFIX_REGEX, trimHyphen);
+
+  if (!options.reactCompat) {
+    // for non-React, remove first hyphen so vendor prefix is not capitalized
+    property = property.replace(VENDOR_PREFIX_REGEX, trimHyphen);
+  }
+
   return property.replace(HYPHEN_REGEX, capitalize);
 };


### PR DESCRIPTION
## What is the motivation for this pull request?

feature:  add option `reactCompat` that capitalizes vendor prefix

bug fix: add `-khtml-` (Konqueror, really old Safari) to vendor prefix regex

## What is the current behavior?

```js
import parse from 'style-to-js';

parse(`
  -webkit-transition: all 4s ease;
  -moz-transition: all 4s ease;
  -ms-transition: all 4s ease;
  -o-transition: all 4s ease;
  -khtml-transition: all 4s ease;
`);
```

Output:

```json
{
  "webkitTransition": "all 4s ease",
  "mozTransition": "all 4s ease",
  "msTransition": "all 4s ease",
  "oTransition": "all 4s ease",
  "KhtmlTransition": "all 4s ease"
}
```

> `KhtmlTransition` is capitalized because it's not added to vendor prefix regex.

## What is the new behavior?

```js
import parse from 'style-to-js';

parse(
  `
    -webkit-transition: all 4s ease;
    -moz-transition: all 4s ease;
    -ms-transition: all 4s ease;
    -o-transition: all 4s ease;
    -khtml-transition: all 4s ease;
  `,
  { reactCompat: true }
);
```

Output:

```json
{
  "WebkitTransition": "all 4s ease",
  "MozTransition": "all 4s ease",
  "MsTransition": "all 4s ease",
  "OTransition": "all 4s ease",
  "KhtmlTransition": "all 4s ease"
}
```

## Checklist:

- [x] Tests
- [x] Documentation
