### PR TITLE
fix: make exports work as documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import parse from 'style-to-js';
 Require with CommonJS:
 
 ```js
-const parse = require('style-to-js').default;
+const parse = require('style-to-js');
 ```
 
 ### Parse style
@@ -209,7 +209,7 @@ parse(
     -o-transition: all 4s ease;
     -khtml-transition: all 4s ease;
   `,
-  { reactCompat: true }
+  { reactCompat: true },
 );
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@rollup/plugin-commonjs": "25.0.7",
         "@rollup/plugin-node-resolve": "15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
-        "@rollup/plugin-typescript": "11.1.6",
         "@types/jest": "29.5.12",
         "@typescript-eslint/eslint-plugin": "7.2.0",
         "@typescript-eslint/parser": "7.2.0",
@@ -2216,32 +2215,6 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/@rollup/plugin-typescript": {
-      "version": "11.1.6",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
-      "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^5.1.0",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.14.0||^3.0.0||^4.0.0",
-        "tslib": "*",
-        "typescript": ">=3.7.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        },
-        "tslib": {
-          "optional": true
-        }
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -9332,16 +9305,6 @@
             "randombytes": "^2.1.0"
           }
         }
-      }
-    },
-    "@rollup/plugin-typescript": {
-      "version": "11.1.6",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
-      "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^5.1.0",
-        "resolve": "^1.22.1"
       }
     },
     "@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@rollup/plugin-commonjs": "25.0.7",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
-    "@rollup/plugin-typescript": "11.1.6",
     "@types/jest": "29.5.12",
     "@typescript-eslint/eslint-plugin": "7.2.0",
     "@typescript-eslint/parser": "7.2.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,26 +1,16 @@
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
-import typescript from '@rollup/plugin-typescript';
 
 const getConfig = (minify = false) => ({
-  input: 'src/index.ts',
+  input: 'cjs/index.js',
   output: {
     file: `umd/style-to-js${minify ? '.min' : ''}.js`,
     format: 'umd',
     name: 'StyleToJS',
     sourcemap: true,
   },
-  plugins: [
-    commonjs(),
-    resolve(),
-    typescript({
-      declaration: false,
-      declarationMap: false,
-      module: 'esnext',
-    }),
-    minify && terser(),
-  ],
+  plugins: [commonjs(), resolve(), minify && terser()],
 });
 
 const configs = [getConfig(), getConfig(true)];

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,8 @@
-import styleToJS from '.';
+import styleToJS = require('.');
+
+it('exposes itself as default', () => {
+  expect(styleToJS).toBe(styleToJS.default);
+});
 
 it('parses empty style to object', () => {
   expect(styleToJS('')).toEqual({});

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,7 @@ interface StyleToJSOptions extends CamelCaseOptions {}
 /**
  * Parses CSS inline style to JavaScript object (camelCased).
  */
-export default function StyleToJS(
-  style: string,
-  options?: StyleToJSOptions,
-): StyleObject {
+function StyleToJS(style: string, options?: StyleToJSOptions): StyleObject {
   const output: StyleObject = {};
 
   if (!style || typeof style !== 'string') {
@@ -27,3 +24,7 @@ export default function StyleToJS(
 
   return output;
 }
+
+StyleToJS.default = StyleToJS;
+
+export = StyleToJS;


### PR DESCRIPTION
## What is the motivation for this pull request?

These changes make usage work as documented. This also makes usage nicer from CJS.

According to the readme, usage was supposed to work like this:

```js
import parse from 'style-to-js';

parse('line-height: 42');
```

But in reality, it worked like this:

```js
import parse from 'style-to-js';

parse.default('line-height: 42');
```

## What is the current behavior?

It works like this:

```js
import parse from 'style-to-js';

parse.default('line-height: 42');
```

```js
const parse = require('style-to-js');

parse.default('line-height: 42');
```

## What is the new behavior?


It works like this:

```js
import parse from 'style-to-js';

parse('line-height: 42');
```

```js
const parse = require('style-to-js');

parse('line-height: 42');
```

The old behaviour is also supported.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation


`@rollup/plugin-typescript` can’t handle TypeScript’s `export =` syntax. As a workaround, the CJS output is now used as the input for the UMD bundle.