### PR TITLE
fix: handle underscore for css custom property regex

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,4 +1,4 @@
-const CUSTOM_PROPERTY_REGEX = /^--[a-zA-Z0-9-]+$/;
+const CUSTOM_PROPERTY_REGEX = /^--[a-zA-Z0-9_-]+$/;
 const HYPHEN_REGEX = /-([a-z])/g;
 const NO_HYPHEN_REGEX = /^[^-]+$/;
 const VENDOR_PREFIX_REGEX = /^-(webkit|moz|ms|o|khtml)-/;


### PR DESCRIPTION
## What is the motivation for this pull request?

Adds underscore support for custom properties

## What is the new behavior?

Fixes #502
