### PR TITLE
ci(github): add UMD page test to workflow test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,13 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Build package
+        run: npm run build
+
+      - name: Test UMD page
+        uses: remarkablemark/page-test-action@501177ce8d124eff6bc5e7b930a3dbd62f28a173 # v1.0.6
+        with:
+          url: http://localhost:8000/examples
+          start: python3 -m http.server
+          wait-on: http://localhost:8000


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): add UMD page test to workflow test.yml

## What is the new behavior?

- Add `page-test-action` step to test the UMD example page
- Start a local Python HTTP server on port 8000
- Navigate to `http://localhost:8000/examples` and check for errors

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation