### PR TITLE
fix(build): bundle `style-to-object` in UMD output

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,39 +1,56 @@
 import { defineConfig, type UserConfig } from 'tsdown';
 
-const baseUmdOptions = {
-  format: 'umd',
+const entry = 'src/index.ts';
+const sourcemap = true;
+const external = ['style-to-object'];
+
+const baseConfig = {
+  entry,
+  sourcemap,
+  target: 'es2023',
+  platform: 'neutral',
+  exports: {
+    packageJson: false,
+    inlinedDependencies: false,
+  },
+  deps: {
+    neverBundle: external,
+  },
+} satisfies UserConfig;
+
+const umdBase = {
+  ...baseConfig,
+  format: 'umd' as const,
   outDir: 'umd',
   globalName: 'StyleToJS',
-  target: 'es2023',
-  outputOptions: {
-    globals: {
-      'style-to-object': 'StyleToObject',
-    },
-    entryFileNames: '[name].js',
+  deps: {
+    alwaysBundle: external,
   },
 } satisfies UserConfig;
 
 export default defineConfig([
+  // ESM and CJS build
   {
+    ...baseConfig,
     format: ['esm', 'cjs'],
-    target: 'es2023',
-    entry: ['src/index.ts'],
-    platform: 'neutral',
-    exports: {
-      packageJson: false,
+    outDir: 'dist',
+    dts: true,
+  },
+
+  // UMD build (unminified)
+  {
+    ...umdBase,
+    outputOptions: {
+      entryFileNames: 'style-to-js.js',
     },
   },
+
+  // UMD build (minified)
   {
-    entry: {
-      'style-to-js': 'src/index.ts',
-    },
-    ...baseUmdOptions,
-  },
-  {
-    entry: {
-      'style-to-js.min': 'src/index.ts',
-    },
+    ...umdBase,
     minify: true,
-    ...baseUmdOptions,
+    outputOptions: {
+      entryFileNames: 'style-to-js.min.js',
+    },
   },
 ]);


### PR DESCRIPTION
## What is the motivation for this pull request?

Refactor the tsdown config to match the `style-to-object` package structure while keeping names consistent with style-to-js, and bundle `style-to-object` into the UMD build so it works standalone.

## What is the current behavior?

The UMD build expects `style-to-object` to be available as an external global (`StyleToObject`), and the config does not use the shared `baseConfig`/`umdBase` pattern.

## What is the new behavior?

- The UMD build bundles `style-to-object` via `deps.alwaysBundle`.
- ESM/CJS builds keep `style-to-object` external via `deps.neverBundle`.
- Config is refactored into shared `baseConfig` and `umdBase` objects.
- Sourcemaps and declaration files are generated.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation